### PR TITLE
fix parse() with undefined variables

### DIFF
--- a/lib/UriTemplate.js
+++ b/lib/UriTemplate.js
@@ -164,19 +164,23 @@ function UriTemplate(template){
 
 		if(!pieces.every(function (piece, pieceIndex) {
 			var options = operatorOptions[piece.operator];
-			var value;
+			var value, values;
 			var offsetBegin = offsets[pieceIndex] + glues[pieceIndex].length;
 			var offsetEnd = offsets[pieceIndex + 1];
 
 			value = str.substring(offsetBegin, offsetEnd);
+			if(value.length === 0) return true;
 			if(value.substring(0, options.prefix.length) !== options.prefix) return false;
 			value = value.substring(options.prefix.length);
-			value = value.split(options.seperator);
-			if(value.length !== piece.variables.length) return false;
+			values = value.split(options.seperator);
 
-			if(!value.every(function(value, valueIndex){
-				var variable = piece.variables[valueIndex];
-				var name = variable.name;
+			if(!piece.variables.every(function(variable, variableIndex){
+				var value = values[variableIndex];
+				var name;
+
+				if(value === undefined) return true;
+
+				name = variable.name;
 				
 				if(options.assignment) {
 					if(value.substring(0, name.length) !== name) return false;

--- a/test/level1.js
+++ b/test/level1.js
@@ -4,12 +4,17 @@ describe('Level 1', function(){
 	var data = {
 		"var": "value"
 		, "hello": "Hello World!"
+		, "undef": undefined
 	};
 	
 	describe('Simple string expansion', function(){
 
 		h.addTest('{var}', 'value', data, true);
 		h.addTest('{hello}', 'Hello%20World%21', data, true);
+		h.addTest('{undef}', '', data, true);
+		h.addTest('x{undef}', 'x', data, true);
+		h.addTest('x{undef}y', 'xy', data, true);
+		h.addTest('{undef}y', 'y', data, true);
 
 		h.addTest('{var}-{hello}', 'value-Hello%20World%21', data, true);
 

--- a/test/level2.js
+++ b/test/level2.js
@@ -5,6 +5,7 @@ describe('Level 2', function(){
 		"var": "value"
 		, "hello": "Hello World!"
 		, "path": "/foo/bar"
+		, "undef": undefined
 	}
 	
 	describe('Reserved string expansion', function(){
@@ -13,6 +14,10 @@ describe('Level 2', function(){
 		h.addTest('{+hello}', 'Hello%20World!', data, true);
 		h.addTest('{+path}/here', '/foo/bar/here', data, true);
 		h.addTest('here?ref={+path}', 'here?ref=/foo/bar', data, true);
+		h.addTest('{+undef}', '', data, true);
+		h.addTest('x{+undef}', 'x', data, true);
+		h.addTest('x{+undef}y', 'xy', data, true);
+		h.addTest('{+undef}y', 'y', data, true);
 
 	});
 
@@ -20,6 +25,10 @@ describe('Level 2', function(){
 		
 		h.addTest('X{#var}', 'X#value', data, true);
 		h.addTest('X{#hello}', 'X#Hello%20World!', data, true);
+		h.addTest('{#undef}', '', data, true);
+		h.addTest('x{#undef}', 'x', data, true);
+		h.addTest('x{#undef}y', 'xy', data, true);
+		h.addTest('{#undef}y', 'y', data, true);
 
 	});
 

--- a/test/level3.js
+++ b/test/level3.js
@@ -8,12 +8,15 @@ describe('Level 3', function(){
 		, "path": "/foo/bar"
 		, "x": "1024"
 		, "y": "768"
+		, "undef": undefined
 	}
 	
 	describe('String expansion with multiple variables', function(){
 		
 		h.addTest('map?{x,y}', 'map?1024,768', data, true);
 		h.addTest('{x,hello,y}', '1024,Hello%20World%21,768', data, true);
+		h.addTest('v?{undef}', 'v?', data, true);
+		h.addTest('v?{x,undef}', 'v?1024', data, true);
 
 	});
 
@@ -21,6 +24,7 @@ describe('Level 3', function(){
 
 		h.addTest('{+x,hello,y}', '1024,Hello%20World!,768', data, true);
 		h.addTest('{+path,x}/here', '/foo/bar,1024/here', data, true);
+		h.addTest('{+path,undef}/here', '/foo/bar/here', data, true);
 		
 	});
 
@@ -28,6 +32,7 @@ describe('Level 3', function(){
 
 		h.addTest('{#x,hello,y}', '#1024,Hello%20World!,768', data, true);
 		h.addTest('{#path,x}/here', '#/foo/bar,1024/here', data, true);
+		h.addTest('{#path,undef}/here', '#/foo/bar/here', data, true);
 		
 	});
 
@@ -35,6 +40,7 @@ describe('Level 3', function(){
 
 		h.addTest('X{.var}', 'X.value', data, true);
 		h.addTest('X{.x,y}', 'X.1024.768', data, true);
+		h.addTest('X{.x,undef}', 'X.1024', data, true);
 		
 	});
 
@@ -42,6 +48,7 @@ describe('Level 3', function(){
 
 		h.addTest('{/var}', '/value', data, true);
 		h.addTest('{/var,x}/here', '/value/1024/here', data, true);
+		h.addTest('{/var,undef}/here', '/value/here', data, true);
 		
 	});
 
@@ -49,6 +56,7 @@ describe('Level 3', function(){
 
 		h.addTest('{;x,y}', ';x=1024;y=768', data, true);
 		h.addTest('{;x,y,empty}', ';x=1024;y=768;empty', data, true);
+		h.addTest('{;x,y,undef}', ';x=1024;y=768', data, true);
 	
 	});
 
@@ -56,6 +64,7 @@ describe('Level 3', function(){
 
 		h.addTest('{?x,y}', '?x=1024&y=768', data, true);
 		h.addTest('{?x,y,empty}', '?x=1024&y=768&empty=', data, true);
+		h.addTest('{?x,y,undef}', '?x=1024&y=768', data, true);
 		
 	});
 
@@ -63,6 +72,7 @@ describe('Level 3', function(){
 
 		h.addTest('?fixed=yes{&x}', '?fixed=yes&x=1024', data, true);
 		h.addTest('{&x,y,empty}', '&x=1024&y=768&empty=', data, true);
+		h.addTest('{&x,y,undef}', '&x=1024&y=768', data, true);
 		
 	});
 


### PR DESCRIPTION
`parse()` would not recognize strings where undefined (ignored) variables are possible.

I've updated the tests to cover (until Level 3) these cases

PS: sorry about this poorly-written PR, but it's 3h30am here and I'm really tired :dizzy_face: 
