### PR TITLE
Fix invalid main path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rfc6570",
   "description": "RFC 6570 compliant uri template parser, builder and router",
-  "main": "src/index.js",
+  "main": "src/main.js",
   "scripts": {
     "test": "mocha test/*"
   },


### PR DESCRIPTION
I ran into an issue when I wanted to try out your library:

``` bash
$ npm install rfc6570
$ node -e "console.log(require('rfc6570'))"
Error: Cannot find module 'rfc6570'
```

Patched:

``` bash
$ npm install rfc6570
$ node -e "console.log(require('rfc6570'))"
{ Router: [Function: Router],
  UriTemplate: [Function: UriTemplate] }
```

Thanks ;)
